### PR TITLE
Refine dataset generation and training workflow

### DIFF
--- a/Data/dataset_gen.py
+++ b/Data/dataset_gen.py
@@ -1,56 +1,75 @@
-import os
-import torch
+"""Utility classes for generating rolling-window graph datasets.
+
+The :class:`MyDataset` class wraps financial time-series data into
+PyTorch-friendly graph samples that can be consumed by GNN models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
 import numpy as np
 import pandas as pd
-from torch.utils.data import Dataset
+import torch
 from scipy.linalg import expm
+from torch.utils.data import Dataset
+
+__all__ = ["MyDataset"]
+
+
+@dataclass(frozen=True)
+class DatasetPaths:
+    """Container tracking the relevant directories for a dataset build."""
+
+    root: Path
+    destination: Path
+
+    @staticmethod
+    def from_strings(root: str, destination: str) -> "DatasetPaths":
+        """Utility helper to construct a :class:`DatasetPaths` object."""
+
+        return DatasetPaths(Path(root).expanduser(), Path(destination).expanduser())
 
 
 class MyDataset(Dataset):
-    """
-    A PyTorch Dataset for rolling-window graphs of company time series.
+    """Rolling-window graph dataset for financial time-series data.
 
-    Parameters:
-      - root (str): directory containing CSVs named {market}_{ticker}_30Y.csv
-      - dest (str): output directory for serialized graphs
-      - market (str): market code prefix in filenames (e.g., 'NASDAQ')
-      - tickers (list[str]): list of ticker symbols to include as nodes (e.g., ['AAPL','MSFT'])
-      - start (str): inclusive window start date 'YYYY-MM-DD'
-      - end (str): inclusive window end date 'YYYY-MM-DD'
-      - window (int): number of past days T to use per graph
-      - mode (str, optional): subfolder label, e.g. 'train' or 'test' (default 'train')
-      - fast_approx (bool, optional): whether to use heat-kernel approximation (default False)
-      - heat_tau (float, optional): time parameter for heat kernel (default 5.0)
-      - sparsify_threshold (float, optional): threshold for sparsification (default 0.3)
-      - log_eps (float, optional): epsilon added before log (default 1e-12)
-      - norm_eps (float, optional): epsilon added for numeric stability in z-score (default 1e-6)
-
-    Graph dict entries:
-      - X: Tensor [N, F * T] node features (log1p normalized)
-      - A: Tensor [N, N] adjacency matrix (entropy-energy or heat-kernel)
-      - Y: Tensor [N] integer labels (days price rose in window)
+    Each sample corresponds to ``window`` consecutive trading days for a
+    collection of tickers.  The features are stacked ``Open``, ``High``,
+    ``Low``, ``Close`` and ``Volume`` values which are log-transformed for
+    numerical stability.  The adjacency matrix can either use a sparsified
+    entropy-energy formulation or a heat-kernel approximation controlled by
+    ``fast_approx``.
     """
+
+    FEATURE_COLUMNS: Sequence[str] = ("Open", "High", "Low", "Close", "Volume")
+
     def __init__(
         self,
         root: str,
         dest: str,
         market: str,
-        tickers: list[str],
+        tickers: Sequence[str],
         start: str,
         end: str,
         window: int,
-        mode: str = 'train',
+        mode: str = "train",
         fast_approx: bool = False,
         heat_tau: float = 5.0,
         sparsify_threshold: float = 0.3,
         log_eps: float = 1e-12,
         norm_eps: float = 1e-6,
-    ):
+    ) -> None:
         super().__init__()
-        self.root = root
-        self.dest = dest
+        if window < 2:
+            msg = "Window length must be at least 2 to build features and labels."
+            raise ValueError(msg)
+
+        self.paths = DatasetPaths.from_strings(root, dest)
         self.market = market
-        self.tickers = tickers
+        self.tickers = list(tickers)
         self.start = pd.to_datetime(start)
         self.end = pd.to_datetime(end)
         self.window = window
@@ -61,122 +80,167 @@ class MyDataset(Dataset):
         self.log_eps = log_eps
         self.norm_eps = norm_eps
 
-        # Load data_frames_full & in-range slice
-        self.data_frames_full = {}
-        self.data_frames = {}
-        for t in self.tickers:
-            path = os.path.join(root, f"{market}_{t}_30Y.csv")
-            if not os.path.exists(path):
-                raise FileNotFoundError(f"CSV file for ticker {t} not found at {path}")
-            df = pd.read_csv(path, parse_dates=[0], index_col=0)
-            self.data_frames_full[t] = df
-            self.data_frames[t] = df.loc[self.start:self.end]
+        self._frames_full: Dict[str, pd.DataFrame] = {}
+        self._frames_range: Dict[str, pd.DataFrame] = {}
+        for ticker in self.tickers:
+            csv_path = self.paths.root / f"{market}_{ticker}_30Y.csv"
+            if not csv_path.exists():
+                raise FileNotFoundError(
+                    f"CSV file for ticker '{ticker}' was not found at {csv_path}"
+                )
+            frame = pd.read_csv(csv_path, parse_dates=[0], index_col=0)
+            self._frames_full[ticker] = frame
+            self._frames_range[ticker] = frame.loc[self.start : self.end]
 
-        # Common trading dates
-        common = set.intersection(*[set(df.index.normalize()) for df in self.data_frames.values()])
-        self.dates = sorted(common)
+        if not self._frames_range:
+            raise ValueError("No tickers were supplied to MyDataset.")
 
-        # Next common date after end for labeling
-        after_sets = [set(df.index.normalize()[df.index.normalize() > self.end]) for df in self.data_frames_full.values()]
-        common_after = set.intersection(*after_sets)
-        self.next_day = min(common_after) if common_after else None
+        self._dates = self._common_trading_days(self._frames_range.values())
+        if len(self._dates) < self.window:
+            raise ValueError("Not enough overlapping trading days to satisfy window size.")
 
-        # Stack raw features: shape (n_dates, N, F)
-        feature_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
-        self.features = np.stack([self.data_frames[t][feature_cols].values for t in self.tickers], axis=1)
+        self._date_to_index = {date: idx for idx, date in enumerate(self._dates)}
+        self._next_day = self._compute_next_day()
+        self._features = self._stack_features()
 
-        # Prepare output
-        out_dir = os.path.join(dest, f"{market}_{mode}_{self.start.date()}_{self.end.date()}_{window}")
-        os.makedirs(out_dir, exist_ok=True)
+        self.graph_dir = self._prepare_output_directory()
+        self.graph_count = self._expected_graphs()
 
-        # Build if missing
-        total = len(self.dates) - window + (1 if self.next_day else 0)
-        if not all(os.path.exists(os.path.join(out_dir, f"graph_{i}.pt")) for i in range(total)):
-            self._build_graphs(out_dir)
+        if not self._graphs_exist():
+            self._build_graphs()
 
-    def __len__(self):
-        return len(self.dates) - self.window + (1 if self.next_day else 0)
+    # ------------------------------------------------------------------
+    # Dataset interface
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        return self.graph_count
 
-    def __getitem__(self, idx):
-        path = os.path.join(
-            self.dest,
-            f"{self.market}_{self.mode}_{self.start.date()}_{self.end.date()}_{self.window}",
-            f"graph_{idx}.pt"
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        graph_path = self.graph_dir / f"graph_{index}.pt"
+        if not graph_path.exists():
+            raise IndexError(f"Graph index {index} is out of bounds for {self.graph_count} samples.")
+        return torch.load(graph_path)
+
+    # ------------------------------------------------------------------
+    # Helper construction routines
+    # ------------------------------------------------------------------
+    def _prepare_output_directory(self) -> Path:
+        directory = (
+            self.paths.destination
+            / f"{self.market}_{self.mode}_{self.start.date()}_{self.end.date()}_{self.window}"
         )
-        return torch.load(path)
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+    def _expected_graphs(self) -> int:
+        return len(self._dates) - self.window + (1 if self._next_day is not None else 0)
+
+    def _graphs_exist(self) -> bool:
+        if self.graph_count <= 0:
+            return False
+        return all((self.graph_dir / f"graph_{i}.pt").exists() for i in range(self.graph_count))
 
     @staticmethod
-    def _entropy(arr: np.ndarray) -> float:
-        vals, counts = np.unique(arr, return_counts=True)
-        p = counts / counts.sum()
-        return -np.sum(p * np.log(p + 1e-12))
+    def _common_trading_days(frames: Iterable[pd.DataFrame]) -> List[pd.Timestamp]:
+        common = None
+        for frame in frames:
+            dates = set(frame.index.normalize())
+            common = dates if common is None else common & dates
+        if not common:
+            return []
+        return sorted(common)
 
-    def _adjacency(self, X: np.ndarray) -> torch.Tensor:
-        """
-        Build adjacency from precomputed feature matrix X (N, T*F).
-        Uses entropy-energy and optional heat diffusion.
-        """
-        N = X.shape[0]
-        energy = np.einsum('ij,ij->i', X, X)
-        entropy = np.apply_along_axis(self._entropy, 1, X)
-        e_ratio = energy[:, None] / (energy[None, :] + self.log_eps)
-        ent_sum = entropy[:, None] + entropy[None, :]
+    def _compute_next_day(self) -> pd.Timestamp | None:
+        after_sets = []
+        for frame in self._frames_full.values():
+            normalized = frame.index.normalize()
+            after_sets.append(set(normalized[normalized > self.end]))
+        if not after_sets:
+            return None
+        intersection = set.intersection(*after_sets)
+        return min(intersection) if intersection else None
 
-        # joint entropy
-        X_pair = np.concatenate([
-            X[:, None, :].repeat(N, axis=1),
-            X[None, :, :].repeat(N, axis=0)
-        ], axis=-1)
-        joint_ent = np.apply_along_axis(self._entropy, 2, X_pair)
+    def _stack_features(self) -> np.ndarray:
+        stacked: List[np.ndarray] = []
+        for date in self._dates:
+            rows = [
+                self._frames_range[ticker].loc[date, self.FEATURE_COLUMNS].to_numpy(dtype=float)
+                for ticker in self.tickers
+            ]
+            stacked.append(np.stack(rows, axis=0))
+        return np.stack(stacked, axis=0)
 
-        A = e_ratio * (np.exp(ent_sum - joint_ent) - 1)
+    # ------------------------------------------------------------------
+    # Graph building
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _entropy(values: np.ndarray) -> float:
+        _, counts = np.unique(values, return_counts=True)
+        probs = counts / counts.sum()
+        return float(-np.sum(probs * np.log(probs + 1e-12)))
+
+    def _adjacency(self, features: np.ndarray) -> torch.Tensor:
+        node_count = features.shape[0]
+        energy = np.einsum("ij,ij->i", features, features)
+        entropy = np.apply_along_axis(self._entropy, 1, features)
+
+        energy_ratio = energy[:, None] / (energy[None, :] + self.log_eps)
+        entropy_sum = entropy[:, None] + entropy[None, :]
+
+        tiled_i = np.repeat(features[:, None, :], node_count, axis=1)
+        tiled_j = np.repeat(features[None, :, :], node_count, axis=0)
+        joint_entropy = np.apply_along_axis(self._entropy, 2, np.concatenate((tiled_i, tiled_j), axis=-1))
+
+        adjacency = energy_ratio * (np.exp(entropy_sum - joint_entropy) - 1.0)
 
         if self.fast_approx:
-            A_t = A + np.eye(N)
-            D_inv_sqrt = np.diag(1.0 / np.sqrt(A_t.sum(axis=1) + self.log_eps))
-            H = D_inv_sqrt @ A_t @ D_inv_sqrt
-            A = expm(-self.heat_tau * (np.eye(N) - H))
+            augmented = adjacency + np.eye(node_count)
+            degree_inv_sqrt = np.diag(1.0 / np.sqrt(augmented.sum(axis=1) + self.log_eps))
+            heat_operator = degree_inv_sqrt @ augmented @ degree_inv_sqrt
+            adjacency = expm(-self.heat_tau * (np.eye(node_count) - heat_operator))
         else:
-            A[A < self.sparsify_threshold] = 0.0
-            A = np.log(A + self.log_eps)
+            adjacency = np.where(adjacency >= self.sparsify_threshold, adjacency, 0.0)
+            adjacency = np.log(adjacency + self.log_eps)
 
-        A = (A + A.T) / 2.0
-        np.fill_diagonal(A, 0.0)
-        return torch.from_numpy(A.astype(np.float32))
+        adjacency = (adjacency + adjacency.T) / 2.0
+        np.fill_diagonal(adjacency, 0.0)
+        return torch.from_numpy(adjacency.astype(np.float32))
 
-    def _build_graphs(self, out_dir: str):
-        feature_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
-        n = len(self.dates)
-        for i in range(n - self.window + (1 if self.next_day else 0)):
-            # select dates
-            if i < len(self.dates) - self.window:
-                slice_dates = self.dates[i:i+self.window+1]
-            else:
-                slice_dates = self.dates[-self.window:] + [self.next_day]
+    def _build_graphs(self) -> None:
+        close_idx = self.FEATURE_COLUMNS.index("Close")
+        for graph_id in range(self.graph_count):
+            date_slice = self._window_dates(graph_id)
+            window_array = np.stack([self._fetch_date_block(date) for date in date_slice], axis=0)
 
-            # collect slices
-            data = []
-            for d in slice_dates:
-                if d in self.dates:
-                    idx = self.dates.index(d)
-                    data.append(self.features[idx])
-                else:
-                    rows = [self.data_frames_full[t].loc[d, feature_cols].values for t in self.tickers]
-                    data.append(np.stack(rows, axis=0))
-            slice_arr = np.stack(data, axis=0)  # (T+1, N, F)
+            close_prices = window_array[:, :, close_idx]
+            labels = (close_prices[-1] > close_prices[-2]).astype(np.int64)
 
-            # label
-            closes = slice_arr[:,:,3]
-            Y = (closes[-1]>closes[-2]).astype(np.int64)
+            hist_window = window_array[:-1]
+            node_count = hist_window.shape[1]
+            node_features = np.log1p(hist_window.transpose(1, 0, 2).reshape(node_count, -1))
 
-            # features: log1p
-            W = slice_arr[:-1]
-            N = W.shape[1]
-            X_norm = np.log1p(W.transpose(1,0,2).reshape(N,-1))
+            adjacency = self._adjacency(node_features)
+            graph = {
+                "X": torch.from_numpy(node_features.astype(np.float32)),
+                "A": adjacency,
+                "Y": torch.from_numpy(labels),
+            }
 
-            # adjacency from normalized X
-            A = self._adjacency(X_norm)
-            X = torch.from_numpy(X_norm.astype(np.float32))
+            torch.save(graph, self.graph_dir / f"graph_{graph_id}.pt")
 
-            torch.save({'X':X,'A':A,'Y':torch.from_numpy(Y)}, os.path.join(out_dir,f"graph_{i}.pt"))
+    def _window_dates(self, graph_id: int) -> List[pd.Timestamp]:
+        if graph_id < len(self._dates) - self.window:
+            return self._dates[graph_id : graph_id + self.window + 1]
+        if self._next_day is None:
+            raise IndexError("Requested extra day for label but next day is unavailable.")
+        return self._dates[-self.window :] + [self._next_day]
+
+    def _fetch_date_block(self, date: pd.Timestamp) -> np.ndarray:
+        if date in self._date_to_index:
+            return self._features[self._date_to_index[date]]
+        rows = []
+        for ticker in self.tickers:
+            row = self._frames_full[ticker].loc[date, self.FEATURE_COLUMNS].to_numpy(dtype=float)
+            rows.append(row)
+        return np.stack(rows, axis=0)
 

--- a/Train_Eval/next_day_movement_prediction.py
+++ b/Train_Eval/next_day_movement_prediction.py
@@ -1,158 +1,196 @@
+"""Training and evaluation script for next-day stock movement prediction."""
+
+from __future__ import annotations
+
 import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
 import torch
 import torch.nn.functional as F
-from dataset_gen import MyDataset
-from dgdnn import DGDNN
-from sklearn.metrics import f1_score, matthews_corrcoef, accuracy_score
+from sklearn.metrics import accuracy_score, f1_score, matthews_corrcoef
 
-# Configure the device for running the model on GPU or CPU
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+from Data.dataset_gen import MyDataset
+from Model.dgdnn import DGDNN
 
-# Configuration (tunable)
-fast_approx = False
-sedate       = ['2013-01-01', '2014-12-31']
-val_sedate   = ['2015-01-01', '2015-06-30']
-test_sedate  = ['2015-07-01', '2017-12-31']
-market       = ['NASDAQ', 'NYSE', 'SSE']
-dataset_type = ['train', 'validation', 'test']
 
-# Paths to company lists
-com_path = [
-    '/content/drive/MyDrive/.../NASDAQ.csv',
-    '/content/drive/MyDrive/.../NYSE.csv',
-    '/content/drive/MyDrive/.../NYSE_missing.csv',
-    '/content/drive/MyDrive/.../SSE-130-tickers.csv'
-]
+@dataclass(frozen=True)
+class DateRange:
+    """Simple container storing the start and end timestamps for a dataset."""
 
-des = '/content/.../data'
-directory = '/content/.../google_finance'
+    start: str
+    end: str
 
-# Read tickers
-NASDAQ_com_list = []
-NYSE_com_list  = []
-NYSE_missing   = [] # replace with the missing tickers 
-SSE_com_list = []
-com_lists = [NASDAQ_com_list, NYSE_com_list, NYSE_missing, SSE_com_list]
-for idx, path in enumerate(com_path):
-    with open(path, newline='') as f:
-        reader = csv.reader(f)
+
+@dataclass
+class ExperimentConfig:
+    """Configuration values for reproducing the experiment."""
+
+    market: str = "NASDAQ"
+    window: int = 19
+    fast_approx: bool = False
+    epochs: int = 6000
+    print_every: int = 100
+    train_range: DateRange = DateRange("2013-01-01", "2014-12-31")
+    val_range: DateRange = DateRange("2015-01-01", "2015-06-30")
+    test_range: DateRange = DateRange("2015-07-01", "2017-12-31")
+
+
+def load_tickers(csv_path: Path) -> List[str]:
+    """Read a single-column CSV file containing ticker symbols."""
+
+    tickers: List[str] = []
+    with csv_path.open(newline="") as fh:
+        reader = csv.reader(fh)
         for row in reader:
             if row:
-                com_lists[idx].append(row[0])
-# filter out missing
-NYSE_com_list = [c for c in NYSE_com_list if c not in NYSE_missing]
+                tickers.append(row[0].strip())
+    return tickers
 
-# Instantiate datasets
-train_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=sedate[0],
-    end=sedate[1],
-    window=19,
-    mode=dataset_type[0],
-    fast_approx=fast_approx
-)
-validation_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=val_sedate[0],
-    end=val_sedate[1],
-    window=19,
-    mode=dataset_type[1],
-    fast_approx=fast_approx
-)
-test_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=test_sedate[0],
-    end=test_sedate[1],
-    window=19,
-    mode=dataset_type[2],
-    fast_approx=fast_approx
-)
 
-# Model hyperparameters
-layers, num_nodes, expansion_step, num_heads = 6, len(NASDAQ_com_list), 7, 2
-classes = 2
-emb_hidden_size, emb_output_size, raw_feature_size = 1024, 256, 64
-timestamp = 19
+def build_datasets(
+    config: ExperimentConfig,
+    tickers: Sequence[str],
+    data_root: Path,
+    cache_dir: Path,
+) -> Tuple[MyDataset, MyDataset, MyDataset]:
+    """Construct train/validation/test datasets with shared parameters."""
 
-diffusion_size = [timestamp * 5, 64, 128, 256, 256, 256, 128]
-emb_size       = [64+64, 128+256, 256+256, 256+256, 256+256, 128+256]
-if num_heads != 2:
-    scale = num_heads / 2.0
-    emb_output_size  = int(round(emb_output_size  * scale))
-    raw_feature_size = int(round(raw_feature_size * scale))
-    diffusion_size = [diffusion_size[0]] + [int(round(x * scale)) for x in diffusion_size[1:]]
-    emb_size       = [int(round(x * scale)) for x in emb_size]
+    kwargs = {
+        "root": str(data_root),
+        "dest": str(cache_dir),
+        "market": config.market,
+        "tickers": tickers,
+        "window": config.window,
+        "fast_approx": config.fast_approx,
+    }
+    train_ds = MyDataset(**kwargs, start=config.train_range.start, end=config.train_range.end, mode="train")
+    val_ds = MyDataset(**kwargs, start=config.val_range.start, end=config.val_range.end, mode="validation")
+    test_ds = MyDataset(**kwargs, start=config.test_range.start, end=config.test_range.end, mode="test")
+    return train_ds, val_ds, test_ds
 
-# Initialize model
-model = DGDNN(
-    diffusion_size,
-    emb_size,
-    emb_hidden_size,
-    emb_output_size,
-    raw_feature_size,
-    classes,
-    layers,
-    num_nodes,
-    expansion_step,
-    num_heads,
-    active=[True]*layers
-).to(device)
 
-# Optimizer
-optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4, weight_decay=1.5e-5)
+def initialize_model(node_count: int, config: ExperimentConfig) -> DGDNN:
+    """Create the DGDNN model using the default hyper-parameters from the paper."""
 
-epochs = 6000
+    layers, expansion_step, num_heads = 6, 7, 2
+    classes = 2
+    emb_hidden_size, emb_output_size, raw_feature_size = 1024, 256, 64
+    timestamp = config.window
 
-# Training loop
-def train():
-    for epoch in range(1, epochs+1):
+    diffusion_size = [timestamp * len(MyDataset.FEATURE_COLUMNS), 64, 128, 256, 256, 256, 128]
+    emb_size = [128, 384, 512, 512, 512, 384]
+
+    if num_heads != 2:
+        scale = num_heads / 2.0
+        emb_output_size = int(round(emb_output_size * scale))
+        raw_feature_size = int(round(raw_feature_size * scale))
+        diffusion_size = [diffusion_size[0]] + [int(round(dim * scale)) for dim in diffusion_size[1:]]
+        emb_size = [int(round(dim * scale)) for dim in emb_size]
+
+    return DGDNN(
+        diffusion_size,
+        emb_size,
+        emb_hidden_size,
+        emb_output_size,
+        raw_feature_size,
+        classes,
+        layers,
+        node_count,
+        expansion_step,
+        num_heads,
+        active=[True] * layers,
+    )
+
+
+def train(
+    model: DGDNN,
+    optimizer: torch.optim.Optimizer,
+    dataset: MyDataset,
+    device: torch.device,
+    epochs: int,
+    print_every: int,
+) -> None:
+    """Run a simple supervised training loop."""
+
+    for epoch in range(1, epochs + 1):
         model.train()
-        total_loss, correct, total = 0.0, 0, 0
-        for sample in train_dataset:
-            X = sample['X'].to(device)
-            A = sample['A'].to(device)
-            C = sample['Y'].to(device).long()
-            optimizer.zero_grad()
-            logits = model(X, A)
-            loss = F.cross_entropy(logits, C)
+        total_loss, total_correct, total_examples = 0.0, 0, 0
+        for sample in dataset:
+            inputs = sample["X"].to(device)
+            adjacency = sample["A"].to(device)
+            targets = sample["Y"].to(device).long()
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(inputs, adjacency)
+            loss = F.cross_entropy(logits, targets)
             loss.backward()
             optimizer.step()
-            total_loss += loss.item()
-            preds = logits.argmax(dim=1)
-            correct += int((preds == C).sum())
-            total += C.size(0)
-        if epoch % 100 == 0:
-            print(f"Epoch {epoch}: loss={total_loss:.4f}, acc={correct/total:.4f}")
 
-# Evaluation function
-def evaluate(dataset, name="Val"):
+            total_loss += loss.item()
+            total_correct += int((logits.argmax(dim=1) == targets).sum())
+            total_examples += targets.size(0)
+
+        if epoch % print_every == 0:
+            accuracy = total_correct / max(total_examples, 1)
+            print(f"Epoch {epoch:05d} | loss={total_loss:.4f} | acc={accuracy:.4f}")
+
+
+@torch.no_grad()
+def evaluate(model: DGDNN, dataset: MyDataset, device: torch.device, name: str) -> Dict[str, float]:
+    """Compute Accuracy, macro-F1 and MCC metrics on a dataset."""
+
     model.eval()
-    all_preds, all_trues = [], []
-    with torch.no_grad():
-        for sample in dataset:
-            X = sample['X'].to(device)
-            A = sample['A'].to(device)
-            C = sample['Y'].to(device)
-            logits = model(X, A)
-            preds = logits.argmax(dim=1).cpu().numpy()
-            trues = C.cpu().numpy()
-            all_preds.extend(preds)
-            all_trues.extend(trues)
-    acc = accuracy_score(all_trues, all_preds)
-    f1  = f1_score(all_trues, all_preds, average='macro')
-    mcc = matthews_corrcoef(all_trues, all_preds)
-    print(f"{name} -- Acc: {acc:.4f}, F1: {f1:.4f}, MCC: {mcc:.4f}")
+    all_preds: List[int] = []
+    all_targets: List[int] = []
+    for sample in dataset:
+        inputs = sample["X"].to(device)
+        adjacency = sample["A"].to(device)
+        targets = sample["Y"].to(device)
+        logits = model(inputs, adjacency)
+        preds = logits.argmax(dim=1).cpu().numpy()
+        all_preds.extend(preds.tolist())
+        all_targets.extend(targets.cpu().numpy().tolist())
+
+    metrics = {
+        "accuracy": accuracy_score(all_targets, all_preds),
+        "f1_macro": f1_score(all_targets, all_preds, average="macro"),
+        "mcc": matthews_corrcoef(all_targets, all_preds),
+    }
+    print(
+        f"{name:>10s} | Acc: {metrics['accuracy']:.4f} | F1: {metrics['f1_macro']:.4f} | MCC: {metrics['mcc']:.4f}"
+    )
+    return metrics
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    data_root = project_root / "Data"
+    cache_dir = data_root / "processed_graphs"
+
+    config = ExperimentConfig()
+    ticker_csv = data_root / f"{config.market}.csv"
+    if not ticker_csv.exists():
+        raise FileNotFoundError(f"Ticker list CSV not found at {ticker_csv}")
+
+    tickers = load_tickers(ticker_csv)
+    if not tickers:
+        raise ValueError("Ticker list is empty; please populate the CSV file with symbols.")
+
+    train_ds, val_ds, test_ds = build_datasets(config, tickers, data_root, cache_dir)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = initialize_model(len(tickers), config).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4, weight_decay=1.5e-5)
+
+    print("Starting training ...")
+    train(model, optimizer, train_ds, device, config.epochs, config.print_every)
+    print("Training complete. Evaluating ...")
+    evaluate(model, val_ds, device, "Validation")
+    evaluate(model, test_ds, device, "Test")
+
 
 if __name__ == "__main__":
-    train()
-    evaluate(validation_dataset, name="Validation")
-    evaluate(test_dataset,       name="Test")
+    main()
+


### PR DESCRIPTION
## Summary
- refactor the dataset generator to use pathlib, richer validation, and clearer documentation while keeping graph outputs consistent
- add helper classes and utilities to streamline building rolling window datasets and adjacency matrices
- modernize the training script with configuration dataclasses, structured dataset creation, and reusable train/evaluate routines

## Testing
- python -m compileall Data Train_Eval

------
https://chatgpt.com/codex/tasks/task_e_68e37b76f0ac8329b2d569b26ecd99db