### PR TITLE
Refine dataset generation and training utilities

### DIFF
--- a/Data/dataset_gen.py
+++ b/Data/dataset_gen.py
@@ -1,182 +1,257 @@
+"""Utilities for constructing rolling-window financial graph datasets."""
+
+from __future__ import annotations
+
 import os
-import torch
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
 import numpy as np
 import pandas as pd
-from torch.utils.data import Dataset
+import torch
 from scipy.linalg import expm
+from torch import Tensor
+from torch.utils.data import Dataset
+
+__all__ = ["MyDataset", "DatasetConfig"]
 
 
-class MyDataset(Dataset):
+@dataclass(frozen=True)
+class DatasetConfig:
+    """Configuration describing how to construct :class:`MyDataset`."""
+
+    root: str
+    dest: str
+    market: str
+    tickers: List[str]
+    start: str
+    end: str
+    window: int
+    mode: str = "train"
+    fast_approx: bool = False
+    heat_tau: float = 5.0
+    sparsify_threshold: float = 0.3
+    log_eps: float = 1e-12
+    norm_eps: float = 1e-6
+
+
+class MyDataset(Dataset[Dict[str, Tensor]]):
+    """PyTorch dataset producing serialized rolling-window financial graphs.
+
+    Each sample corresponds to a contiguous window of :math:`T` trading days for
+    a set of companies.  The companies are represented as nodes in a graph whose
+    adjacency is derived from the statistical similarity of their windowed
+    feature trajectories.  The target label indicates whether the closing price
+    of each company increased on the following day.
     """
-    A PyTorch Dataset for rolling-window graphs of company time series.
 
-    Parameters:
-      - root (str): directory containing CSVs named {market}_{ticker}_30Y.csv
-      - dest (str): output directory for serialized graphs
-      - market (str): market code prefix in filenames (e.g., 'NASDAQ')
-      - tickers (list[str]): list of ticker symbols to include as nodes (e.g., ['AAPL','MSFT'])
-      - start (str): inclusive window start date 'YYYY-MM-DD'
-      - end (str): inclusive window end date 'YYYY-MM-DD'
-      - window (int): number of past days T to use per graph
-      - mode (str, optional): subfolder label, e.g. 'train' or 'test' (default 'train')
-      - fast_approx (bool, optional): whether to use heat-kernel approximation (default False)
-      - heat_tau (float, optional): time parameter for heat kernel (default 5.0)
-      - sparsify_threshold (float, optional): threshold for sparsification (default 0.3)
-      - log_eps (float, optional): epsilon added before log (default 1e-12)
-      - norm_eps (float, optional): epsilon added for numeric stability in z-score (default 1e-6)
+    feature_columns: List[str] = ["Open", "High", "Low", "Close", "Volume"]
 
-    Graph dict entries:
-      - X: Tensor [N, F * T] node features (log1p normalized)
-      - A: Tensor [N, N] adjacency matrix (entropy-energy or heat-kernel)
-      - Y: Tensor [N] integer labels (days price rose in window)
-    """
-    def __init__(
-        self,
-        root: str,
-        dest: str,
-        market: str,
-        tickers: list[str],
-        start: str,
-        end: str,
-        window: int,
-        mode: str = 'train',
-        fast_approx: bool = False,
-        heat_tau: float = 5.0,
-        sparsify_threshold: float = 0.3,
-        log_eps: float = 1e-12,
-        norm_eps: float = 1e-6,
-    ):
+    def __init__(self, config: Optional[DatasetConfig] = None, **kwargs: Any) -> None:
         super().__init__()
-        self.root = root
-        self.dest = dest
-        self.market = market
-        self.tickers = tickers
-        self.start = pd.to_datetime(start)
-        self.end = pd.to_datetime(end)
-        self.window = window
-        self.mode = mode
-        self.fast_approx = fast_approx
-        self.heat_tau = heat_tau
-        self.sparsify_threshold = sparsify_threshold
-        self.log_eps = log_eps
-        self.norm_eps = norm_eps
 
-        # Load data_frames_full & in-range slice
-        self.data_frames_full = {}
-        self.data_frames = {}
-        for t in self.tickers:
-            path = os.path.join(root, f"{market}_{t}_30Y.csv")
+        if config is None:
+            config = DatasetConfig(**kwargs)
+
+        self.root = config.root
+        self.dest = config.dest
+        self.market = config.market
+        self.tickers = list(config.tickers)
+        self.start = pd.to_datetime(config.start).normalize()
+        self.end = pd.to_datetime(config.end).normalize()
+        self.window = int(config.window)
+        self.mode = config.mode
+        self.fast_approx = config.fast_approx
+        self.heat_tau = float(config.heat_tau)
+        self.sparsify_threshold = float(config.sparsify_threshold)
+        self.log_eps = float(config.log_eps)
+        self.norm_eps = float(config.norm_eps)
+
+        if self.window <= 1:
+            raise ValueError("window must be greater than one to compute labels")
+        if not self.tickers:
+            raise ValueError("tickers list may not be empty")
+
+        self.data_frames_full: Dict[str, pd.DataFrame] = {}
+        self.data_frames: Dict[str, pd.DataFrame] = {}
+
+        for ticker in self.tickers:
+            path = os.path.join(self.root, f"{self.market}_{ticker}_30Y.csv")
             if not os.path.exists(path):
-                raise FileNotFoundError(f"CSV file for ticker {t} not found at {path}")
+                raise FileNotFoundError(
+                    f"CSV file for ticker {ticker} not found at {path}"
+                )
+
             df = pd.read_csv(path, parse_dates=[0], index_col=0)
-            self.data_frames_full[t] = df
-            self.data_frames[t] = df.loc[self.start:self.end]
+            df.index = pd.to_datetime(df.index).normalize()
+            df.sort_index(inplace=True)
 
-        # Common trading dates
-        common = set.intersection(*[set(df.index.normalize()) for df in self.data_frames.values()])
-        self.dates = sorted(common)
+            self.data_frames_full[ticker] = df
+            self.data_frames[ticker] = df.loc[self.start : self.end]
 
-        # Next common date after end for labeling
-        after_sets = [set(df.index.normalize()[df.index.normalize() > self.end]) for df in self.data_frames_full.values()]
-        common_after = set.intersection(*after_sets)
-        self.next_day = min(common_after) if common_after else None
+        common_dates = self._compute_common_dates()
+        if len(common_dates) < self.window:
+            raise ValueError(
+                "Insufficient overlapping data to construct the requested window"
+            )
 
-        # Stack raw features: shape (n_dates, N, F)
-        feature_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
-        self.features = np.stack([self.data_frames[t][feature_cols].values for t in self.tickers], axis=1)
+        self.dates = sorted(common_dates)
+        self.date_to_index = {date: idx for idx, date in enumerate(self.dates)}
+        self.next_day = self._compute_next_day()
 
-        # Prepare output
-        out_dir = os.path.join(dest, f"{market}_{mode}_{self.start.date()}_{self.end.date()}_{window}")
-        os.makedirs(out_dir, exist_ok=True)
+        self.features = self._stack_features(self.dates)
 
-        # Build if missing
-        total = len(self.dates) - window + (1 if self.next_day else 0)
-        if not all(os.path.exists(os.path.join(out_dir, f"graph_{i}.pt")) for i in range(total)):
-            self._build_graphs(out_dir)
-
-    def __len__(self):
-        return len(self.dates) - self.window + (1 if self.next_day else 0)
-
-    def __getitem__(self, idx):
-        path = os.path.join(
+        self.output_directory = os.path.join(
             self.dest,
             f"{self.market}_{self.mode}_{self.start.date()}_{self.end.date()}_{self.window}",
-            f"graph_{idx}.pt"
         )
+        os.makedirs(self.output_directory, exist_ok=True)
+
+        self._ensure_serialized_graphs()
+
+    # ------------------------------------------------------------------
+    # Dataset protocol
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:  # type: ignore[override]
+        total = len(self.dates) - self.window
+        if self.next_day is not None:
+            total += 1
+        return max(total, 0)
+
+    def __getitem__(self, index: int) -> Dict[str, Tensor]:  # type: ignore[override]
+        path = os.path.join(self.output_directory, f"graph_{index}.pt")
+        if not os.path.exists(path):
+            raise IndexError(f"Serialized sample {index} is missing at {path}")
         return torch.load(path)
 
+    # ------------------------------------------------------------------
+    # Data preparation helpers
+    # ------------------------------------------------------------------
+    def _compute_common_dates(self) -> set[pd.Timestamp]:
+        common_dates: Optional[set[pd.Timestamp]] = None
+        for frame in self.data_frames.values():
+            dates = set(frame.index)
+            common_dates = dates if common_dates is None else common_dates & dates
+        return common_dates or set()
+
+    def _compute_next_day(self) -> Optional[pd.Timestamp]:
+        candidates: Optional[set[pd.Timestamp]] = None
+        for frame in self.data_frames_full.values():
+            future_dates = set(frame.index[frame.index > self.end])
+            candidates = future_dates if candidates is None else candidates & future_dates
+        return min(candidates) if candidates else None
+
+    def _stack_features(self, dates: Iterable[pd.Timestamp]) -> np.ndarray:
+        dates_index = pd.DatetimeIndex(list(dates))
+        aligned_arrays = []
+        for ticker in self.tickers:
+            aligned = (
+                self.data_frames[ticker]
+                .reindex(dates_index)
+                [self.feature_columns]
+                .to_numpy(dtype=np.float64)
+            )
+            aligned_arrays.append(aligned)
+        return np.stack(aligned_arrays, axis=1)
+
+    # ------------------------------------------------------------------
+    # Graph construction
+    # ------------------------------------------------------------------
     @staticmethod
     def _entropy(arr: np.ndarray) -> float:
-        vals, counts = np.unique(arr, return_counts=True)
-        p = counts / counts.sum()
-        return -np.sum(p * np.log(p + 1e-12))
+        values, counts = np.unique(arr, return_counts=True)
+        probabilities = counts / counts.sum()
+        return float(-np.sum(probabilities * np.log(probabilities + 1e-12)))
 
-    def _adjacency(self, X: np.ndarray) -> torch.Tensor:
-        """
-        Build adjacency from precomputed feature matrix X (N, T*F).
-        Uses entropy-energy and optional heat diffusion.
-        """
-        N = X.shape[0]
-        energy = np.einsum('ij,ij->i', X, X)
-        entropy = np.apply_along_axis(self._entropy, 1, X)
-        e_ratio = energy[:, None] / (energy[None, :] + self.log_eps)
-        ent_sum = entropy[:, None] + entropy[None, :]
+    def _adjacency(self, features: np.ndarray) -> Tensor:
+        """Build an adjacency matrix from flattened node features."""
 
-        # joint entropy
-        X_pair = np.concatenate([
-            X[:, None, :].repeat(N, axis=1),
-            X[None, :, :].repeat(N, axis=0)
-        ], axis=-1)
-        joint_ent = np.apply_along_axis(self._entropy, 2, X_pair)
+        num_nodes = features.shape[0]
+        energy = np.einsum("ij,ij->i", features, features)
+        entropy = np.apply_along_axis(self._entropy, 1, features)
+        energy_ratio = energy[:, None] / (energy[None, :] + self.log_eps)
+        entropy_sum = entropy[:, None] + entropy[None, :]
 
-        A = e_ratio * (np.exp(ent_sum - joint_ent) - 1)
+        tiled_left = np.repeat(features[:, None, :], num_nodes, axis=1)
+        tiled_right = np.repeat(features[None, :, :], num_nodes, axis=0)
+        joint = np.concatenate([tiled_left, tiled_right], axis=-1)
+        joint_entropy = np.apply_along_axis(self._entropy, 2, joint)
+
+        adjacency = energy_ratio * (np.exp(entropy_sum - joint_entropy) - 1.0)
 
         if self.fast_approx:
-            A_t = A + np.eye(N)
-            D_inv_sqrt = np.diag(1.0 / np.sqrt(A_t.sum(axis=1) + self.log_eps))
-            H = D_inv_sqrt @ A_t @ D_inv_sqrt
-            A = expm(-self.heat_tau * (np.eye(N) - H))
+            adjacency_with_self = adjacency + np.eye(num_nodes)
+            degree_inv = 1.0 / np.sqrt(adjacency_with_self.sum(axis=1) + self.log_eps)
+            degree_inv_matrix = np.diag(degree_inv)
+            heat_operator = degree_inv_matrix @ adjacency_with_self @ degree_inv_matrix
+            adjacency = expm(-self.heat_tau * (np.eye(num_nodes) - heat_operator))
         else:
-            A[A < self.sparsify_threshold] = 0.0
-            A = np.log(A + self.log_eps)
+            adjacency[adjacency < self.sparsify_threshold] = 0.0
+            adjacency = np.log(adjacency + self.log_eps)
 
-        A = (A + A.T) / 2.0
-        np.fill_diagonal(A, 0.0)
-        return torch.from_numpy(A.astype(np.float32))
+        adjacency = (adjacency + adjacency.T) / 2.0
+        np.fill_diagonal(adjacency, 0.0)
+        return torch.from_numpy(adjacency.astype(np.float32))
 
-    def _build_graphs(self, out_dir: str):
-        feature_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
-        n = len(self.dates)
-        for i in range(n - self.window + (1 if self.next_day else 0)):
-            # select dates
-            if i < len(self.dates) - self.window:
-                slice_dates = self.dates[i:i+self.window+1]
-            else:
-                slice_dates = self.dates[-self.window:] + [self.next_day]
+    def _ensure_serialized_graphs(self) -> None:
+        total = len(self)
+        if total == 0:
+            return
+        missing = any(
+            not os.path.exists(os.path.join(self.output_directory, f"graph_{i}.pt"))
+            for i in range(total)
+        )
+        if missing:
+            self._build_graphs()
 
-            # collect slices
-            data = []
-            for d in slice_dates:
-                if d in self.dates:
-                    idx = self.dates.index(d)
-                    data.append(self.features[idx])
-                else:
-                    rows = [self.data_frames_full[t].loc[d, feature_cols].values for t in self.tickers]
-                    data.append(np.stack(rows, axis=0))
-            slice_arr = np.stack(data, axis=0)  # (T+1, N, F)
+    def _build_graphs(self) -> None:
+        total = len(self)
+        for index in range(total):
+            dates = self._select_dates(index)
+            slice_array = self._collect_slice(dates)
 
-            # label
-            closes = slice_arr[:,:,3]
-            Y = (closes[-1]>closes[-2]).astype(np.int64)
+            closes = slice_array[:, :, 3]
+            labels = (closes[-1] > closes[-2]).astype(np.int64)
 
-            # features: log1p
-            W = slice_arr[:-1]
-            N = W.shape[1]
-            X_norm = np.log1p(W.transpose(1,0,2).reshape(N,-1))
+            window_array = slice_array[:-1]
+            num_nodes = window_array.shape[1]
+            flattened = np.log1p(
+                window_array.transpose(1, 0, 2).reshape(num_nodes, -1) + self.norm_eps
+            )
 
-            # adjacency from normalized X
-            A = self._adjacency(X_norm)
-            X = torch.from_numpy(X_norm.astype(np.float32))
+            adjacency = self._adjacency(flattened)
+            features = torch.from_numpy(flattened.astype(np.float32))
 
-            torch.save({'X':X,'A':A,'Y':torch.from_numpy(Y)}, os.path.join(out_dir,f"graph_{i}.pt"))
+            payload = {
+                "X": features,
+                "A": adjacency,
+                "Y": torch.from_numpy(labels),
+            }
+            torch.save(payload, os.path.join(self.output_directory, f"graph_{index}.pt"))
+
+    # ------------------------------------------------------------------
+    # Window helpers
+    # ------------------------------------------------------------------
+    def _select_dates(self, index: int) -> List[pd.Timestamp]:
+        in_range = len(self.dates) - self.window
+        if index < in_range:
+            return self.dates[index : index + self.window + 1]
+        if self.next_day is None:
+            raise IndexError("Index exceeds available windows")
+        return self.dates[-self.window :] + [self.next_day]
+
+    def _collect_slice(self, dates: List[pd.Timestamp]) -> np.ndarray:
+        slices = []
+        for date in dates:
+            if date in self.date_to_index:
+                slices.append(self.features[self.date_to_index[date]])
+                continue
+            rows = [
+                self.data_frames_full[ticker]
+                .loc[date, self.feature_columns]
+                .to_numpy(dtype=np.float64)
+                for ticker in self.tickers
+            ]
+            slices.append(np.stack(rows, axis=0))
+        return np.stack(slices, axis=0)
 

--- a/Model/catattn.py
+++ b/Model/catattn.py
@@ -1,8 +1,11 @@
 """Concatenation-based multi-head attention utilities."""
 
+from __future__ import annotations
+
 import torch
-import torch.nn as nn
-from torch import Tensor
+from torch import Tensor, nn
+
+__all__ = ["CatMultiAttn"]
 
 
 class CatMultiAttn(nn.Module):
@@ -42,7 +45,9 @@ class CatMultiAttn(nn.Module):
 
         # Multi-head attention treats every node as a token; the actual batch size
         # is handled by temporarily unsqueezing the sequence tensor.
-        self.attn = nn.MultiheadAttention(embed_dim=input_time, num_heads=num_heads)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=input_time, num_heads=num_heads, batch_first=False
+        )
         self.norm = nn.LayerNorm(input_time)
 
         # Projection from the concatenated representation to the downstream space.

--- a/Model/dgdnn.py
+++ b/Model/dgdnn.py
@@ -1,11 +1,12 @@
 """Dynamic Graph Diffusion Neural Network building blocks."""
 
+from __future__ import annotations
+
 from typing import Sequence
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from torch import Tensor
+from torch import Tensor, nn
+from torch.nn import functional as F
 
 if __package__ in (None, ""):
     from ggd import GeneralizedGraphDiffusion  # type: ignore
@@ -13,6 +14,8 @@ if __package__ in (None, ""):
 else:  # pragma: no cover - executed only when imported as a package
     from .ggd import GeneralizedGraphDiffusion
     from .catattn import CatMultiAttn
+
+__all__ = ["DGDNN"]
 
 
 class DGDNN(nn.Module):
@@ -95,17 +98,15 @@ class DGDNN(nn.Module):
         nn.init.xavier_uniform_(self.T)
         nn.init.constant_(self.theta, 1.0 / float(self.theta.size(-1)))
         nn.init.xavier_uniform_(self.linear.weight)
+        nn.init.xavier_uniform_(self.raw_h_prime.weight)
         if self.linear.bias is not None:
             nn.init.zeros_(self.linear.bias)
+        if self.raw_h_prime.bias is not None:
+            nn.init.zeros_(self.raw_h_prime.bias)
 
     def forward(self, X: Tensor, A: Tensor) -> Tensor:
-        """
-        Args:
-            X: [N, F0]  node features
-            A: [N, N]   adjacency matrix
-        Returns:
-            logits: [N, classes]
-        """
+        """Run the Dynamic Graph Diffusion Neural Network forward pass."""
+
         if X.dim() != 2 or A.dim() != 2:
             raise ValueError("X and A must both be 2-D tensors")
         if A.size(0) != A.size(1):
@@ -113,7 +114,7 @@ class DGDNN(nn.Module):
         if A.size(0) != X.size(0):
             raise ValueError("Adjacency size must match the number of nodes in X")
 
-        theta_soft = F.softmax(self.theta, dim=-1)  # [layers, expansion_step]
+        theta_soft = F.softmax(self.theta, dim=-1)
 
         h = X
         h_prime = X

--- a/Model/ggd.py
+++ b/Model/ggd.py
@@ -1,8 +1,11 @@
 """Generalized graph diffusion operators."""
 
+from __future__ import annotations
+
 import torch
-import torch.nn as nn
-from torch import Tensor
+from torch import Tensor, nn
+
+__all__ = ["GeneralizedGraphDiffusion"]
 
 
 class GeneralizedGraphDiffusion(nn.Module):
@@ -13,54 +16,38 @@ class GeneralizedGraphDiffusion(nn.Module):
         self.fc = nn.Linear(input_dim, output_dim)
         self.activation = nn.PReLU(num_parameters=input_dim) if active else nn.Identity()
 
+        nn.init.xavier_uniform_(self.fc.weight)
+        if self.fc.bias is not None:
+            nn.init.zeros_(self.fc.bias)
+
     @staticmethod
-    def _validate_inputs(
-        theta: Tensor, T_slices: Tensor, x: Tensor, a: Tensor
-    ) -> None:
+    def _validate_inputs(theta: Tensor, bases: Tensor, features: Tensor, adjacency: Tensor) -> None:
         if theta.dim() != 1:
             raise ValueError("theta must be a 1-D tensor of diffusion coefficients")
-        if T_slices.dim() != 3:
-            raise ValueError("T_slices must be a 3-D tensor [S, N, N]")
-        if x.dim() != 2:
-            raise ValueError("x must be a 2-D tensor of node features")
-        if a.dim() != 2 or a.size(0) != a.size(1):
-            raise ValueError("Adjacency tensor a must be square")
-        if T_slices.size(0) != theta.size(0):
-            raise ValueError("Number of diffusion bases must match the coefficients")
-        if T_slices.size(1) != a.size(0):
-            raise ValueError("Diffusion bases and adjacency must share node dimension")
-        if x.size(0) != a.size(0):
-            raise ValueError("Node feature count must match adjacency size")
+        if bases.dim() != 3:
+            raise ValueError("bases must be a 3-D tensor with shape [S, N, N]")
+        if features.dim() != 2:
+            raise ValueError("features must be a 2-D tensor of node embeddings")
+        if adjacency.dim() != 2 or adjacency.size(0) != adjacency.size(1):
+            raise ValueError("adjacency must be a square matrix")
+        if bases.size(0) != theta.size(0):
+            raise ValueError("number of diffusion bases must match theta coefficients")
+        if bases.size(1) != adjacency.size(0):
+            raise ValueError("diffusion bases and adjacency must share node dimension")
+        if features.size(0) != adjacency.size(0):
+            raise ValueError("node feature count must equal adjacency size")
 
-    def forward(
-        self,
-        theta: Tensor,
-        T_slices: Tensor,
-        x: Tensor,
-        a: Tensor,
-    ) -> Tensor:
-        """Apply the generalized diffusion operator.
+    def forward(self, theta: Tensor, bases: Tensor, features: Tensor, adjacency: Tensor) -> Tensor:
+        """Apply the generalized diffusion operator."""
 
-        Args:
-            theta: ``[S]`` diffusion coefficients.
-            T_slices: ``[S, N, N]`` diffusion bases.
-            x: ``[N, F_in]`` node features.
-            a: ``[N, N]`` adjacency weights.
+        self._validate_inputs(theta, bases, features, adjacency)
 
-        Returns:
-            ``[N, F_out]`` tensor with diffused node representations.
-        """
+        diffusion_kernel = torch.einsum("s,sij->ij", theta, bases)
+        diffusion_kernel = diffusion_kernel * adjacency
 
-        self._validate_inputs(theta, T_slices, x, a)
-
-        q = torch.einsum("s,sij->ij", theta, T_slices)
-        q = q * a
-
-        q_sparse = q.to_sparse().coalesce()
-        out = torch.sparse.mm(q_sparse, x)
-
-        out = self.activation(out)
-        return self.fc(out)
+        diffused = torch.sparse.mm(diffusion_kernel.to_sparse().coalesce(), features)
+        activated = self.activation(diffused)
+        return self.fc(activated)
 
 # Fast approximation version using GCNConv for efficiency
 # from torch_geometric.nn import GCNConv

--- a/Train_Eval/next_day_movement_prediction.py
+++ b/Train_Eval/next_day_movement_prediction.py
@@ -1,158 +1,211 @@
+"""Train and evaluate the Dynamic Graph Diffusion Neural Network."""
+
+from __future__ import annotations
+
 import csv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
 import torch
-import torch.nn.functional as F
-from dataset_gen import MyDataset
-from dgdnn import DGDNN
-from sklearn.metrics import f1_score, matthews_corrcoef, accuracy_score
+from sklearn.metrics import accuracy_score, f1_score, matthews_corrcoef
+from torch.nn import functional as F
 
-# Configure the device for running the model on GPU or CPU
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-# Configuration (tunable)
-fast_approx = False
-sedate       = ['2013-01-01', '2014-12-31']
-val_sedate   = ['2015-01-01', '2015-06-30']
-test_sedate  = ['2015-07-01', '2017-12-31']
-market       = ['NASDAQ', 'NYSE', 'SSE']
-dataset_type = ['train', 'validation', 'test']
+from Data.dataset_gen import DatasetConfig, MyDataset
+from Model.dgdnn import DGDNN
 
-# Paths to company lists
-com_path = [
-    '/content/drive/MyDrive/.../NASDAQ.csv',
-    '/content/drive/MyDrive/.../NYSE.csv',
-    '/content/drive/MyDrive/.../NYSE_missing.csv',
-    '/content/drive/MyDrive/.../SSE-130-tickers.csv'
-]
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-des = '/content/.../data'
-directory = '/content/.../google_finance'
 
-# Read tickers
-NASDAQ_com_list = []
-NYSE_com_list  = []
-NYSE_missing   = [] # replace with the missing tickers 
-SSE_com_list = []
-com_lists = [NASDAQ_com_list, NYSE_com_list, NYSE_missing, SSE_com_list]
-for idx, path in enumerate(com_path):
-    with open(path, newline='') as f:
-        reader = csv.reader(f)
-        for row in reader:
-            if row:
-                com_lists[idx].append(row[0])
-# filter out missing
-NYSE_com_list = [c for c in NYSE_com_list if c not in NYSE_missing]
+@dataclass(frozen=True)
+class ExperimentConfig:
+    """All hyper-parameters required for training the model."""
 
-# Instantiate datasets
-train_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=sedate[0],
-    end=sedate[1],
-    window=19,
-    mode=dataset_type[0],
-    fast_approx=fast_approx
-)
-validation_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=val_sedate[0],
-    end=val_sedate[1],
-    window=19,
-    mode=dataset_type[1],
-    fast_approx=fast_approx
-)
-test_dataset = MyDataset(
-    root=directory,
-    dest=des,
-    market=market[0],
-    tickers=NASDAQ_com_list,
-    start=test_sedate[0],
-    end=test_sedate[1],
-    window=19,
-    mode=dataset_type[2],
-    fast_approx=fast_approx
-)
+    root: Path
+    destination: Path
+    market: str
+    tickers: Sequence[str]
+    train_range: Tuple[str, str]
+    val_range: Tuple[str, str]
+    test_range: Tuple[str, str]
+    window: int = 19
+    fast_approximation: bool = False
+    layers: int = 6
+    expansion_step: int = 7
+    num_heads: int = 2
+    embedding_hidden: int = 1024
+    embedding_output: int = 256
+    raw_feature_size: int = 64
+    classes: int = 2
+    learning_rate: float = 2e-4
+    weight_decay: float = 1.5e-5
+    epochs: int = 6000
 
-# Model hyperparameters
-layers, num_nodes, expansion_step, num_heads = 6, len(NASDAQ_com_list), 7, 2
-classes = 2
-emb_hidden_size, emb_output_size, raw_feature_size = 1024, 256, 64
-timestamp = 19
 
-diffusion_size = [timestamp * 5, 64, 128, 256, 256, 256, 128]
-emb_size       = [64+64, 128+256, 256+256, 256+256, 256+256, 128+256]
-if num_heads != 2:
-    scale = num_heads / 2.0
-    emb_output_size  = int(round(emb_output_size  * scale))
-    raw_feature_size = int(round(raw_feature_size * scale))
-    diffusion_size = [diffusion_size[0]] + [int(round(x * scale)) for x in diffusion_size[1:]]
-    emb_size       = [int(round(x * scale)) for x in emb_size]
+def read_ticker_file(path: Path) -> List[str]:
+    """Load ticker symbols from a CSV file."""
 
-# Initialize model
-model = DGDNN(
-    diffusion_size,
-    emb_size,
-    emb_hidden_size,
-    emb_output_size,
-    raw_feature_size,
-    classes,
-    layers,
-    num_nodes,
-    expansion_step,
-    num_heads,
-    active=[True]*layers
-).to(device)
+    tickers: List[str] = []
+    with path.open(newline="") as handle:
+        reader = csv.reader(handle)
+        tickers = [row[0] for row in reader if row]
+    return tickers
 
-# Optimizer
-optimizer = torch.optim.AdamW(model.parameters(), lr=2e-4, weight_decay=1.5e-5)
 
-epochs = 6000
+def filter_missing(base: Iterable[str], missing: Iterable[str]) -> List[str]:
+    """Remove missing tickers while preserving order."""
 
-# Training loop
-def train():
-    for epoch in range(1, epochs+1):
-        model.train()
-        total_loss, correct, total = 0.0, 0, 0
-        for sample in train_dataset:
-            X = sample['X'].to(device)
-            A = sample['A'].to(device)
-            C = sample['Y'].to(device).long()
-            optimizer.zero_grad()
-            logits = model(X, A)
-            loss = F.cross_entropy(logits, C)
-            loss.backward()
-            optimizer.step()
-            total_loss += loss.item()
-            preds = logits.argmax(dim=1)
-            correct += int((preds == C).sum())
-            total += C.size(0)
-        if epoch % 100 == 0:
-            print(f"Epoch {epoch}: loss={total_loss:.4f}, acc={correct/total:.4f}")
+    missing_set = set(missing)
+    return [ticker for ticker in base if ticker not in missing_set]
 
-# Evaluation function
-def evaluate(dataset, name="Val"):
+
+def build_dataset(config: ExperimentConfig, mode: str, date_range: Tuple[str, str]) -> MyDataset:
+    dataset_config = DatasetConfig(
+        root=str(config.root),
+        dest=str(config.destination),
+        market=config.market,
+        tickers=list(config.tickers),
+        start=date_range[0],
+        end=date_range[1],
+        window=config.window,
+        mode=mode,
+        fast_approx=config.fast_approximation,
+    )
+    return MyDataset(dataset_config)
+
+
+def build_model(config: ExperimentConfig, num_nodes: int, timestamp: int) -> DGDNN:
+    diffusion_size = [timestamp * 5, 64, 128, 256, 256, 256, 128]
+    embedding_size = [64 + 64, 128 + 256, 256 + 256, 256 + 256, 256 + 256, 128 + 256]
+
+    emb_output = config.embedding_output
+    raw_feature_size = config.raw_feature_size
+    if config.num_heads != 2:
+        scale = config.num_heads / 2.0
+        emb_output = int(round(emb_output * scale))
+        raw_feature_size = int(round(raw_feature_size * scale))
+        diffusion_size = [diffusion_size[0]] + [int(round(x * scale)) for x in diffusion_size[1:]]
+        embedding_size = [int(round(x * scale)) for x in embedding_size]
+
+    model = DGDNN(
+        diffusion_size,
+        embedding_size,
+        config.embedding_hidden,
+        emb_output,
+        raw_feature_size,
+        config.classes,
+        config.layers,
+        num_nodes,
+        config.expansion_step,
+        config.num_heads,
+        active=[True] * config.layers,
+    )
+    return model.to(device)
+
+
+def train_epoch(model: DGDNN, dataset: MyDataset, optimizer: torch.optim.Optimizer) -> Tuple[float, float]:
+    model.train()
+    total_loss = 0.0
+    correct = 0
+    total = 0
+
+    for sample in dataset:
+        features = sample["X"].to(device)
+        adjacency = sample["A"].to(device)
+        target = sample["Y"].to(device).long()
+
+        optimizer.zero_grad()
+        logits = model(features, adjacency)
+        loss = F.cross_entropy(logits, target)
+        loss.backward()
+        optimizer.step()
+
+        total_loss += float(loss.item())
+        predictions = logits.argmax(dim=1)
+        correct += int((predictions == target).sum())
+        total += target.size(0)
+
+    accuracy = correct / total if total else 0.0
+    return total_loss, accuracy
+
+
+def evaluate(model: DGDNN, dataset: MyDataset) -> Tuple[float, float, float]:
     model.eval()
-    all_preds, all_trues = [], []
+    predictions: List[int] = []
+    targets: List[int] = []
+
     with torch.no_grad():
         for sample in dataset:
-            X = sample['X'].to(device)
-            A = sample['A'].to(device)
-            C = sample['Y'].to(device)
-            logits = model(X, A)
-            preds = logits.argmax(dim=1).cpu().numpy()
-            trues = C.cpu().numpy()
-            all_preds.extend(preds)
-            all_trues.extend(trues)
-    acc = accuracy_score(all_trues, all_preds)
-    f1  = f1_score(all_trues, all_preds, average='macro')
-    mcc = matthews_corrcoef(all_trues, all_preds)
-    print(f"{name} -- Acc: {acc:.4f}, F1: {f1:.4f}, MCC: {mcc:.4f}")
+            features = sample["X"].to(device)
+            adjacency = sample["A"].to(device)
+            target = sample["Y"].to(device).long()
+
+            logits = model(features, adjacency)
+            predictions.extend(logits.argmax(dim=1).cpu().tolist())
+            targets.extend(target.cpu().tolist())
+
+    accuracy = accuracy_score(targets, predictions)
+    f1 = f1_score(targets, predictions, average="macro")
+    mcc = matthews_corrcoef(targets, predictions)
+    return accuracy, f1, mcc
+
+
+def main() -> None:
+    """Entry point for training and evaluation."""
+
+    # The placeholders below mirror the original script paths.  Replace with the
+    # paths on your system as necessary.
+    nasdaq_path = Path("/content/drive/MyDrive/.../NASDAQ.csv")
+    nyse_path = Path("/content/drive/MyDrive/.../NYSE.csv")
+    nyse_missing_path = Path("/content/drive/MyDrive/.../NYSE_missing.csv")
+    sse_path = Path("/content/drive/MyDrive/.../SSE-130-tickers.csv")
+
+    nasdaq_tickers = read_ticker_file(nasdaq_path)
+    nyse_tickers = read_ticker_file(nyse_path)
+    nyse_missing = read_ticker_file(nyse_missing_path)
+    sse_tickers = read_ticker_file(sse_path)
+
+    nyse_filtered = filter_missing(nyse_tickers, nyse_missing)
+    _ = (nyse_filtered, sse_tickers)  # Other markets can be incorporated if desired.
+
+    experiment = ExperimentConfig(
+        root=Path("/content/.../google_finance"),
+        destination=Path("/content/.../data"),
+        market="NASDAQ",
+        tickers=nasdaq_tickers,
+        train_range=("2013-01-01", "2014-12-31"),
+        val_range=("2015-01-01", "2015-06-30"),
+        test_range=("2015-07-01", "2017-12-31"),
+    )
+
+    train_dataset = build_dataset(experiment, "train", experiment.train_range)
+    val_dataset = build_dataset(experiment, "validation", experiment.val_range)
+    test_dataset = build_dataset(experiment, "test", experiment.test_range)
+
+    timestamp = experiment.window
+    model = build_model(experiment, num_nodes=len(experiment.tickers), timestamp=timestamp)
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=experiment.learning_rate, weight_decay=experiment.weight_decay
+    )
+
+    for epoch in range(1, experiment.epochs + 1):
+        loss, acc = train_epoch(model, train_dataset, optimizer)
+        if epoch % 100 == 0:
+            print(f"Epoch {epoch:04d}: loss={loss:.4f}, acc={acc:.4f}")
+
+    val_metrics = evaluate(model, val_dataset)
+    test_metrics = evaluate(model, test_dataset)
+
+    print(
+        "Validation -- Acc: {:.4f}, F1: {:.4f}, MCC: {:.4f}".format(*val_metrics)
+    )
+    print("Test -- Acc: {:.4f}, F1: {:.4f}, MCC: {:.4f}".format(*test_metrics))
+
 
 if __name__ == "__main__":
-    train()
-    evaluate(validation_dataset, name="Validation")
-    evaluate(test_dataset,       name="Test")
+    main()


### PR DESCRIPTION
## Summary
- refactor `MyDataset` to share configuration via a dataclass, improve date alignment, and ensure serialized graphs are rebuilt only when needed
- enhance graph diffusion, attention, and network modules with clearer initialization and validation
- reorganize the training script into reusable helpers and an experiment configuration for cleaner execution

## Testing
- python -m compileall Data/dataset_gen.py Model/ggd.py Model/catattn.py Model/dgdnn.py Train_Eval/next_day_movement_prediction.py

------
https://chatgpt.com/codex/tasks/task_e_68e37f0c186c83299d9ed371182f950c