### PR TITLE
Harden dataset config validation and diffusion operator math

### DIFF
--- a/Data/dataset_gen.py
+++ b/Data/dataset_gen.py
@@ -16,6 +16,9 @@ from torch.utils.data import Dataset
 __all__ = ["MyDataset", "DatasetConfig"]
 
 
+VALID_DATASET_MODES = {"train", "validation", "test"}
+
+
 @dataclass(frozen=True)
 class DatasetConfig:
     """Configuration describing how to construct :class:`MyDataset`."""
@@ -33,6 +36,32 @@ class DatasetConfig:
     sparsify_threshold: float = 0.3
     log_eps: float = 1e-12
     norm_eps: float = 1e-6
+
+    def __post_init__(self) -> None:
+        if not self.root:
+            raise ValueError("root directory must be provided")
+        if not self.dest:
+            raise ValueError("destination directory must be provided")
+        if not self.tickers:
+            raise ValueError("tickers list may not be empty")
+        if self.window <= 1:
+            raise ValueError("window must be greater than one to compute labels")
+
+        try:
+            start_ts = pd.to_datetime(self.start).normalize()
+            end_ts = pd.to_datetime(self.end).normalize()
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            raise ValueError("start and end must be parseable as dates") from exc
+
+        if start_ts > end_ts:
+            raise ValueError("start date must be earlier than or equal to end date")
+
+        mode = self.mode.lower()
+        if mode not in VALID_DATASET_MODES:
+            allowed = ", ".join(sorted(VALID_DATASET_MODES))
+            raise ValueError(f"mode must be one of: {allowed}")
+
+        object.__setattr__(self, "mode", mode)
 
 
 class MyDataset(Dataset[Dict[str, Tensor]]):

--- a/Model/ggd.py
+++ b/Model/ggd.py
@@ -42,10 +42,25 @@ class GeneralizedGraphDiffusion(nn.Module):
 
         self._validate_inputs(theta, bases, features, adjacency)
 
-        diffusion_kernel = torch.einsum("s,sij->ij", theta, bases)
-        diffusion_kernel = diffusion_kernel * adjacency
+        device = features.device
+        if adjacency.device != device:
+            raise ValueError("features and adjacency must reside on the same device")
+        if bases.device != device or theta.device != device:
+            raise ValueError("Diffusion parameters must reside on the same device as inputs")
 
-        diffused = torch.sparse.mm(diffusion_kernel.to_sparse().coalesce(), features)
+        diffusion_kernel = torch.einsum("s,sij->ij", theta, bases)
+
+        if adjacency.layout == torch.strided:
+            adjacency_matrix = adjacency
+        else:
+            adjacency_matrix = adjacency.to_dense()
+
+        dtype = features.dtype
+        diffusion_kernel = diffusion_kernel.to(dtype)
+        adjacency_matrix = adjacency_matrix.to(dtype)
+        diffused = (diffusion_kernel * adjacency_matrix) @ features.to(dtype)
+        diffused = diffused.to(dtype)
+
         activated = self.activation(diffused)
         return self.fc(activated)
 


### PR DESCRIPTION
## Summary
- add validation to `DatasetConfig` to normalise the mode field and guard against invalid paths or date ranges
- tighten `GeneralizedGraphDiffusion` by checking device alignment and using a dense-matrix matmul path that works with sparse adjacencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e38732d204832993cd7b9ae61f860a